### PR TITLE
Allow Uninstall

### DIFF
--- a/BaseInstallerBuild/TemplateFramework.wxs
+++ b/BaseInstallerBuild/TemplateFramework.wxs
@@ -210,6 +210,11 @@
 				  Target="[APPFOLDER]$(var.SafeApplicationName).exe"
 				  WorkingDirectory="APPFOLDER"
 				  Icon="Application_Icon.ico"/>
+			<Shortcut Id="UninstallProduct"
+				  Name="Uninstall $(var.ApplicationName)"
+				  Target="[SystemFolder]msiexec.exe"
+				  Arguments="/x [ProductCode]"
+				  Description="Uninstalls $(var.ApplicationName)" />
 			<RegistryValue Root="HKCU" Key="Software\Microsoft\$(var.SafeApplicationName)$(var.MajorVersion)" Name="installed" Type="integer" Value="1" KeyPath="yes"/>
 		</Component>
 	</DirectoryRef>


### PR DESCRIPTION
Add an uninstall shortcut to the Start menu
so that users who install using the msi will
be able to uninstall. (Note that uninstalling
from this shortcut will uninstall
My App # Packages (installed by msi)
but not
My App #.#.# (installed by exe)
However, My App #.#.# can still be uninstalled
through Add or Remove Programs.
This addresses, but does not resolve,
https://github.com/sillsdev/genericinstaller/issues/5
(and might should be rolled back
 when the real problem is resolved)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/genericinstaller/11)
<!-- Reviewable:end -->
