### PR TITLE
Prefer Windows whoami

### DIFF
--- a/BaseInstallerBuild/buildBaseInstaller.bat
+++ b/BaseInstallerBuild/buildBaseInstaller.bat
@@ -38,7 +38,7 @@ if "%Arch%" == "" set Arch=x86
 
 REM ICE validation must be run with admin privileges. The jenkins user is not an admin. Suppress ICE validation so it doesn't fail.
 REM For some reason, ICE08 works without admin, and the quickest way to suppress everything else on the command line is to specify one ICE to run.
-whoami /groups | find "BUILTIN\Administrators" > nul
+C:\Windows\System32\whoami /groups | find "BUILTIN\Administrators" > nul
 if errorlevel 1 set SuppressICE=-ice:ICE08
 
 REM Ensure WiX tools are on the PATH


### PR DESCRIPTION
In Jenkins builds, the first whoami on the PATH is the Unix version, which does not list Windows groups, which we need to determine whether the build is being run by an administrator user.
Include the full path to whoami.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/genericinstaller/30)
<!-- Reviewable:end -->
