### PR TITLE
Timestamp when Signing

### DIFF
--- a/BaseInstallerBuild/Framework.wxs
+++ b/BaseInstallerBuild/Framework.wxs
@@ -176,7 +176,7 @@
 				<Shortcut Id="ApplicationDesktopShortcut"
 					Name="$(var.ApplicationName) $(var.MajorVersion)"
 					Description="$(var.ApplicationName) $(var.MajorVersion)"
-					Target="[APPFOLDER]$(var.ShortcutTargetName)"
+					Target="[APPFOLDER]$(var.SafeApplicationName).exe"
 					WorkingDirectory="APPFOLDER"
 					Icon="Application_Icon.ico"/>
 				<RemoveFolder Id="DesktopFolder" On="uninstall"/>

--- a/BaseInstallerBuild/buildBaseInstaller.bat
+++ b/BaseInstallerBuild/buildBaseInstaller.bat
@@ -24,10 +24,6 @@ SHIFT
 SET APPDATADIR=%1
 SHIFT
 
-REM File to be invoked by desktop shortcut.
-REM REVIEW (Hasso) 2018.03: this is neither complicated, customizable, nor used multiple times. It's not our job to set.
-SET ShortcutTargetName=%SafeAppName%.exe
-
 REM To protect the password for the certfile, you can configure your build process to read the password from an unversioned file and pass it into the CERTPASS variable.
 SET CopyrightYear=%1
 SHIFT
@@ -51,7 +47,7 @@ heat.exe dir %APPBUILDDIR% -cg HarvestedAppFiles -gg -scom -sreg -sfrag -srd -sw
 heat.exe dir %APPDATADIR% -cg HarvestedDataFiles -gg -scom -sreg -sfrag -srd -sw5150 -sw5151 -dr HARVESTDATAFOLDER -var var.APPDATADIR -t KeyPathFix.xsl -out DataHarvest.wxs
 
 @REM Compile (candle) and Link (light) the MSI file.
-candle.exe -arch %Arch% -dApplicationName=%AppName% -dSafeApplicationName=%SafeAppName% -dManufacturer=%Manufacturer% -dVersionNumber=%Version% -dMajorVersion=%Major% -dMinorVersion=%Minor% -dAPPBUILDDIR=%APPBUILDDIR% -dAPPDATADIR=%APPDATADIR% -dUpgradeCode=%UPGRADECODEGUID% -dProductCode=%PRODUCTIDGUID% -dShortcutTargetName=%ShortcutTargetName% Framework.wxs AppHarvest.wxs DataHarvest.wxs WixUI_DialogFlow.wxs GIInstallDirDlg.wxs GIProgressDlg.wxs GIWelcomeDlg.wxs GICustomizeDlg.wxs GISetupTypeDlg.wxs
+candle.exe -arch %Arch% -dApplicationName=%AppName% -dSafeApplicationName=%SafeAppName% -dManufacturer=%Manufacturer% -dVersionNumber=%Version% -dMajorVersion=%Major% -dMinorVersion=%Minor% -dAPPBUILDDIR=%APPBUILDDIR% -dAPPDATADIR=%APPDATADIR% -dUpgradeCode=%UPGRADECODEGUID% -dProductCode=%PRODUCTIDGUID% Framework.wxs AppHarvest.wxs DataHarvest.wxs WixUI_DialogFlow.wxs GIInstallDirDlg.wxs GIProgressDlg.wxs GIWelcomeDlg.wxs GICustomizeDlg.wxs GISetupTypeDlg.wxs
 
 light.exe Framework.wixobj AppHarvest.wixobj DataHarvest.wixobj WixUI_DialogFlow.wixobj GIInstallDirDlg.wixobj GIProgressDlg.wixobj GIWelcomeDlg.wixobj GICustomizeDlg.wixobj GISetupTypeDlg.wixobj -ext WixUIExtension -ext WixUtilExtension.dll -cultures:en-us -loc WixUI_en-us.wxl %SuppressICE% -sw1076 -out %SafeAppName%_%Version%.msi
 

--- a/BaseInstallerBuild/signingProxy.bat
+++ b/BaseInstallerBuild/signingProxy.bat
@@ -4,12 +4,12 @@
 
 where sign >nul 2>nul
 if %errorlevel%==0 (
-	sign %1
+	sign %*
 ) else (
 	where signtool.exe >nul 2>nul
 	if %errorlevel%==0 (
 		echo Signing with specified code signing certificate ...
-		signtool.exe sign /f %CERTPATH% /p %CERTPASS% %1
+		signtool.exe sign /f %CERTPATH% /p %CERTPASS% /t http://timestamp.comodoca.com/authenticode %*
 	)
 	if not %errorlevel%==0 (
 		echo Unable to sign %1; skipping.


### PR DESCRIPTION
* allow multiple arguments to signingProxy.bat
* pass timestamp argument when calling signtool.exe
* remove unnecessary ShortcutTargetName variable

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/genericinstaller/41)
<!-- Reviewable:end -->
