### PR TITLE
Fix: LT-19379 Win32 Installer can't install dependencies

### DIFF
--- a/BaseInstallerBuild/Bundle.wxs
+++ b/BaseInstallerBuild/Bundle.wxs
@@ -207,7 +207,7 @@
 				  DownloadUrl="$(var.VC17RedistWebLink)"
                   InstallCommand="/quiet /norestart"
 				  DetectCondition="CPP2017Redist">
-				<RemotePayload Description="Microsoft Visual C++ 2017 Redistributable (x86) - 14.13.26020.0" Hash="33000000c4e989f87a8150e9ff0000000000c4"
+				<RemotePayload Description="Microsoft Visual C++ 2017 Redistributable (x86) - 14.13.26020.0" Hash="725656A642A518F8060892D8AB82226C1430C964"
 					ProductName="Microsoft Visual C++ 2017 Redistributable (x86) - 14.13.26020.0" Size="14575896" Version="14.13.26020.0" />
 			</ExePackage>
 		</PackageGroup>

--- a/BaseInstallerBuild/OfflineBundle.wxs
+++ b/BaseInstallerBuild/OfflineBundle.wxs
@@ -129,7 +129,7 @@
                      Value="Installed"
                      Result="value"/>
 		<PackageGroup Id="redist_vc15">
-			<ExePackage Id="vc15" Cache="no" PerMachine="yes" Vital="yes" Compressed="no" Permanent="yes"
+			<ExePackage Id="vc15" Cache="no" PerMachine="yes" Vital="yes" Compressed="yes" Permanent="yes"
 				  Name="vcredist_x86.exe"
 				  SourceFile="..\libs\vcredist_2015_x86.exe"
                   InstallCommand="/quiet /norestart"
@@ -145,11 +145,12 @@
                      Value="Installed"
                      Result="value"/>
 		<PackageGroup Id="redist_vc17">
-			<ExePackage Id="vc17" Cache="no" PerMachine="yes" Vital="yes" Compressed="no" Permanent="yes"
+			<ExePackage Id="vc17" Cache="no" PerMachine="yes" Vital="yes" Compressed="yes" Permanent="yes"
 				  Name="vcredist_x86.exe"
 				  SourceFile="..\libs\vcredist_2017_x86.exe"
                   InstallCommand="/quiet /norestart"
 				  DetectCondition="CPP2017Redist">
+				 <ExitCode Value="1638" Behavior="success"/> <!-- Don't fail if newer version is installed -->
 			</ExePackage>
 		</PackageGroup>
 	</Fragment>


### PR DESCRIPTION
 * Modified the hash id
 * Corrected the offline bundle compressed option

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/genericinstaller/45)
<!-- Reviewable:end -->
