### PR TITLE
Fix: LT-19409 FW9 installer repair corrupts Icu54 path

### DIFF
--- a/BaseInstallerBuild/Framework.wxs
+++ b/BaseInstallerBuild/Framework.wxs
@@ -185,7 +185,7 @@
 					<util:PermissionEx User="AuthenticatedUser" GenericAll="yes" />
 				</CreateFolder>
 				<RegistryKey Root='HKLM' Key='SOFTWARE\[REGISTRYKEY]' ForceDeleteOnUninstall='yes'>
-					<RegistryValue Name="[HARVESTDATAFOLDERREGSZNAME]" Type='string' Value='[HARVESTDATAFOLDER]' KeyPath='yes'/>
+					<RegistryValue Name="[HARVESTDATAFOLDERREGSZNAME]" Type='string' Value='[OVRHARVESTDATAFOLDER]' KeyPath='yes'/>
 				</RegistryKey>
 			</Component>
 		</Directory>


### PR DESCRIPTION
 * Fixed when repair, value assigned overharvestdatafolder.