### PR TITLE
Allow two registry searches for DataFolder (LT-19916)

### DIFF
--- a/BaseInstallerBuild/Framework.wxs
+++ b/BaseInstallerBuild/Framework.wxs
@@ -88,8 +88,8 @@
 	<Property Id="GALATIA_INSTALLED" Value='False'/>
 	<Property Id="EZRA_INSTALLED" Value='False'/>-->
 
-	<Property Id="DATAFOLDER" Secure='yes'>
-	  <RegistrySearch Id='RegSearchDataFolder' Root='HKLM' Key='SOFTWARE\[REGISTRYKEY]' Name='[DATAFOLDERREGSZNAME]' Type='raw'/>
+	<Property Id="REGDATAFOLDER" Secure='yes'>
+	  <RegistrySearch Id='RegSearchDataFolder' Root='HKLM' Key='SOFTWARE\[REGISTRYKEY]' Name='[DATAFOLDERREGSZNAME]' Type='directory'/>
 	</Property>
 
 	<CustomAction Id='SetDefDataFolder' Property='DEFDATAFOLDER' Value='[WindowsVolume]My$(var.SafeApplicationName)DataFolder' />
@@ -105,6 +105,7 @@
 	<SetProperty Id='HARVESTDATAFOLDERREGSZNAME' Value='Data_Directory'  Before="AppSearch">not HARVESTDATAFOLDERREGSZNAME</SetProperty>
 	<CustomAction Id='UseDefDataFolder' Property='DATAFOLDER' Value='[DEFDATAFOLDER]' />
 	<CustomAction Id='UseOvrDataFolder' Property='DATAFOLDER' Value='[OVRDATAFOLDER]' /> <!-- from Overrides.wxi -->
+	<CustomAction Id='UseLegDataFolder' Property='DATAFOLDER' Value='[LEGDATAFOLDER]' /> <!-- legacy data folder from a previous version -->
 	<CustomAction Id='UseRegDataFolder' Property='DATAFOLDER' Value='[REGDATAFOLDER]' />
 	<!-- TODO (HASSO) 2018.02: if there is no OVRHARVESTDATAFOLDER, make HARVESTDATAFOLDER whatever the user picked for DATAFOLDER -->
 	<CustomAction Id='UseDefHarvestDataFolder' Property='HARVESTDATAFOLDER' Value='[DATAFOLDER]' />
@@ -133,9 +134,10 @@
 		<Custom Action="UseDefAppFolder" Before="AppSearch">(NOT REGAPPFOLDER) and (NOT OVRAPPFOLDER)</Custom>
 		<Custom Action="UseOvrAppFolder" Before="AppSearch">(NOT REGAPPFOLDER) and (OVRAPPFOLDER)</Custom>
 		<Custom Action="UseRegAppFolder" Before="AppSearch">REGAPPFOLDER</Custom>
-		<Custom Action="UseDefDataFolder" After="AppSearch">(NOT REGDATAFOLDER) and (NOT OVRDATAFOLDER)</Custom>
-		<Custom Action="UseOvrDataFolder" After="AppSearch">(NOT REGDATAFOLDER) and (OVRDATAFOLDER)</Custom>
-		<Custom Action="UseRegDataFolder" After="AppSearch">REGDATAFOLDER</Custom>
+		<Custom Action="UseDefDataFolder" After="AppSearch">(NOT REGDATAFOLDER) and (NOT LEGDATAFOLDER) and (NOT OVRDATAFOLDER)</Custom>
+		<Custom Action="UseOvrDataFolder" After="AppSearch">(NOT REGDATAFOLDER) and (NOT LEGDATAFOLDER) and (OVRDATAFOLDER)</Custom>
+		<Custom Action="UseLegDataFolder" After="AppSearch">(NOT REGDATAFOLDER) and (LEGDATAFOLDER)</Custom>
+		<Custom Action="UseRegDataFolder" After="AppSearch">(REGDATAFOLDER)</Custom>
 		<Custom Action="UseDefHarvestDataFolder" After="AppSearch">NOT OVRHARVESTDATAFOLDER</Custom>
 		<Custom Action="UseOvrHarvestDataFolder" After="AppSearch">OVRHARVESTDATAFOLDER</Custom>
 	</InstallUISequence>

--- a/Common/Overrides.wxi
+++ b/Common/Overrides.wxi
@@ -12,6 +12,12 @@
 	<!--SetProperty Id="OVRAPPFOLDER" Value="[ProgramFilesFolder]\SIL\$(var.SafeApplicationName)$(var.MajorVersion)\" Before="AppSearch"/-->
 	<!-- the folder in which the user's data will be kept (the user will be able to change this) -->
 	<!--SetProperty Id="OVRDATAFOLDER" Value="[PersonalFolder]\My$(var.SafeApplicationName)Files" Before="AppSearch"/-->
+	<!-- the folder in which the user's data was stored in the previous version of the app
+		(if set, the Legacy Data Folder takes precedence over the Override Data Folder
+		but not the data folder already recorded in the registry for the current version -->
+	<!--Property Id="LEGDATAFOLDER">
+		<RegistrySearch Id="LegacyDataFolder" Key="SOFTWARE\SIL\$(var.ApplicationName)\1.1" Name="DataDir" Root="HKLM" Type="directory" Win64="no"/>
+	</Property-->
 	<!-- the folder in which the shipping (harvested) data will be installed (default is the same as the user-selected data directory) -->
 	<!--SetProperty Id="OVRHARVESTDATAFOLDER" Value="[LocalAppDataFolder]\SIL_International\$(var.SafeApplicationName)\$(var.VersionNumber)" Before="AppSearch"/-->
 


### PR DESCRIPTION
- Allow searching the registry for a data folder from a previous
  version of the app (search specified and performed in overrides.wxi)
- FieldWorks changes its registry key location at each major version,
  so this allows major and nonmajor upgrades to preserve settings
- Not allowing extra registry searches for the app folder
  to encourage (trick?) users to install in the default location

Required for https://jira.sil.org/browse/LT-19916

Change-Id: Ie27a82834b0b9f5cdb024d66bb54a5152880108d

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/genericinstaller/53)
<!-- Reviewable:end -->
