### PR TITLE
Update the Visual Studio C++ redistributables

### DIFF
--- a/BaseInstallerBuild/Bundle.wxs
+++ b/BaseInstallerBuild/Bundle.wxs
@@ -82,12 +82,13 @@
 
 	<?if $(sys.BUILDARCH)="x86"?>
 	<!-- 32bit VC++ redistributable download section -->
+	<!-- When updating or adding a redistributable you can generate the RemotePayload with the WIX's heat tool -->
+	<!-- e.g. "%WIX%\bin\heat" payload C:\fwroot\fw\PatchableInstaller\libs\vcredist_2008_x64.exe -o c:\Repositories\fw\PatchableInstaller\VC2008Frag.wxs -->
 	<?define VC08RedistWebLink = https://download.microsoft.com/download/5/D/8/5D8C65CB-C849-4025-8E95-C3966CAFD8AE/vcredist_x86.exe ?>
 	<?define VC10RedistWebLink = https://download.microsoft.com/download/1/6/5/165255E7-1014-4D0A-B094-B6A430A6BFFC/vcredist_x86.exe ?>
 	<?define VC11RedistWebLink = https://download.microsoft.com/download/1/6/B/16B06F60-3B20-4FF2-B699-5E9B7962F9AE/VSU_4/vcredist_x86.exe ?>
-	<?define VC12RedistWebLink = http://download.microsoft.com/download/0/5/6/056dcda9-d667-4e27-8001-8a0c6971d6b1/vcredist_x86.exe ?>
-	<?define VC15RedistWebLink = https://download.microsoft.com/download/9/3/F/93FCF1E7-E6A4-478B-96E7-D4B285925B00/vc_redist.x86.exe ?>
-	<?define VC17RedistWebLink = https://download.visualstudio.microsoft.com/download/pr/11687613/88b50ce70017bf10f2d56d60fcba6ab1/VC_redist.x86.exe ?>
+	<?define VC12RedistWebLink = https://download.microsoft.com/download/0/5/6/056dcda9-d667-4e27-8001-8a0c6971d6b1/vcredist_x86.exe ?>
+	<?define VC15to19RedistWebLink = https://aka.ms/vs/16/release/vc_redist.x86.exe ?>
 	<Fragment>
 		<util:RegistrySearch Root="HKLM"
                      Key="Software\Microsoft\Windows\CurrentVersion\Uninstall\{9A25302D-30C0-39D9-BD6F-21E6EC160475}"
@@ -166,25 +167,8 @@
 					Version="12.0.40660.0"
 					ProductName="Microsoft Visual C++ 2013 Redistributable (x86) - 12.0.40660"
 					Description="Microsoft Visual C++ 2013 Redistributable (x86) - 12.0.40660"
-					Hash="2a07a32330d5131665378836d542478d3e7bd137"/>
+					Hash="2A07A32330D5131665378836D542478D3E7BD137" />
 				<ExitCode Value="1638" Behavior="success"/> <!-- Don't fail if newer version is installed -->
-			</ExePackage>
-		</PackageGroup>
-	</Fragment>
-	<Fragment>
-		<util:RegistrySearch Root="HKLM"
-                     Key="SOFTWARE\Microsoft\VisualStudio\14.0\VC\Runtimes\x86"
-                     Variable="CPP2015Redist"
-                     Value="Installed"
-                     Result="value"/>
-		<PackageGroup Id="redist_vc15">
-			<ExePackage Id="vc15" Cache="no" PerMachine="yes" Vital="yes" Compressed="no" Permanent="yes"
-				  Name="vcredist_x86.exe"
-				  DownloadUrl="$(var.VC15RedistWebLink)"
-                  InstallCommand="/quiet /norestart"
-				  DetectCondition="CPP2015Redist">
-				<RemotePayload Description="Microsoft Visual C++ 2015 Redistributable (x86) - 14.0.23026" Hash="BFB74E498C44D3A103CA3AA2831763FB417134D1"
-					ProductName="Microsoft Visual C++ 2015 Redistributable (x86) - 14.0.23026" Size="13767776" Version="14.0.23026.0" />
 			</ExePackage>
 		</PackageGroup>
 	</Fragment>
@@ -194,25 +178,30 @@
                      Variable="CPP2017Redist"
                      Value="Installed"
                      Result="value"/>
-		<PackageGroup Id="redist_vc17">
+		<PackageGroup Id="redist_vc15to19">
 			<ExePackage Id="vc17" Cache="no" PerMachine="yes" Vital="yes" Compressed="no" Permanent="yes"
 				  Name="vcredist_x86.exe"
-				  DownloadUrl="$(var.VC17RedistWebLink)"
+				  DownloadUrl="$(var.VC15to19RedistWebLink)"
                   InstallCommand="/quiet /norestart"
 				  DetectCondition="CPP2017Redist">
-				<RemotePayload Description="Microsoft Visual C++ 2017 Redistributable (x86) - 14.13.26020.0" Hash="725656A642A518F8060892D8AB82226C1430C964"
-					ProductName="Microsoft Visual C++ 2017 Redistributable (x86) - 14.13.26020.0" Size="14575896" Version="14.13.26020.0" />
+				<RemotePayload
+					Size="14327344"
+					Version="14.28.29914.0"
+					ProductName="Microsoft Visual C++ 2015-2019 Redistributable (x86) - 14.28.29914"
+					Description="Microsoft Visual C++ 2015-2019 Redistributable (x86) - 14.28.29914"
+					Hash="D848A57ADB68456B91BD8BA5108C116DE8DA8F25" />
 			</ExePackage>
 		</PackageGroup>
 	</Fragment>
 	<?elseif $(sys.BUILDARCH)="x64"?>
 	<!-- 64bit  VC++ redistributable download section -->
+	<!-- When updating or adding a redistributable you can generate the RemotePayload with the WIX's heat tool -->
+	<!-- e.g. "%WIX%\bin\heat" payload C:\fwroot\fw\PatchableInstaller\libs\vcredist_2008_x64.exe -o c:\Repositories\fw\PatchableInstaller\VC2008Frag.wxs -->
 	<?define VC08RedistWebLink = https://download.microsoft.com/download/5/D/8/5D8C65CB-C849-4025-8E95-C3966CAFD8AE/vcredist_x64.exe ?>
 	<?define VC10RedistWebLink = https://download.microsoft.com/download/1/6/5/165255E7-1014-4D0A-B094-B6A430A6BFFC/vcredist_x64.exe ?>
 	<?define VC11RedistWebLink = https://download.microsoft.com/download/1/6/B/16B06F60-3B20-4FF2-B699-5E9B7962F9AE/VSU_4/vcredist_x64.exe ?>
-	<?define VC12RedistWebLink = https://download.microsoft.com/download/2/E/6/2E61CFA4-993B-4DD4-91DA-3737CD5CD6E3/vcredist_x64.exe ?>
-	<?define VC15RedistWebLink = https://download.microsoft.com/download/9/3/F/93FCF1E7-E6A4-478B-96E7-D4B285925B00/vc_redist.x64.exe ?>
-	<?define VC17RedistWebLink = https://download.visualstudio.microsoft.com/download/pr/11687625/2cd2dba5748dc95950a5c42c2d2d78e4/VC_redist.x64.exe ?>
+	<?define VC12RedistWebLink = https://download.microsoft.com/download/0/5/6/056DCDA9-D667-4E27-8001-8A0C6971D6B1/vcredist_x64.exe ?>
+	<?define VC15to19RedistWebLink = https://aka.ms/vs/16/release/vc_redist.x64.exe ?>
 	<Fragment>
 		<util:RegistrySearch Root="HKLM"
                      Key="Software\Microsoft\Windows\CurrentVersion\Uninstall\{8220EEFE-38CD-377E-8595-13398D740ACE}"
@@ -225,8 +214,8 @@
 				  DownloadUrl="$(var.VC08RedistWebLink)"
                   InstallCommand="/Q /norestart"
 				  DetectCondition="CPP2008Redist">
-				<RemotePayload Description="Microsoft Visual C++ 2008 Redistributable Setup" Hash="A7C83077B8A28D409E36316D2D7321FA0CCDB7E8"
-					ProductName="Microsoft Visual C++ 2008 Redistributable" Size="5207896" Version="9.0.30729.5677" />
+				<RemotePayload Description="Microsoft Visual C++ 2008 Redistributable Setup" Hash="CE8FF6572E86B0BBA39D88FA3A6D56B59100613D"
+					ProductName="Microsoft Visual C++ 2008 Redistributable" Size="5211080" Version="9.0.30729.5677" />
 				<ExitCode Value="1638" Behavior="success"/> <!-- Don't fail if newer version is installed -->
 			</ExePackage>
 		</PackageGroup>
@@ -300,34 +289,8 @@
 				  DownloadUrl="$(var.VC12RedistWebLink)"
                   InstallCommand="/quiet /norestart"
 				  DetectCondition="(CPP2012Redist32) OR (CPP2012Redist64)">
-				<RemotePayload Description="Microsoft Visual C++ 2013 Redistributable (x64) - 12.0.30501" Hash="8BF41BA9EEF02D30635A10433817DBB6886DA5A2"
-					ProductName="Microsoft Visual C++ 2013 Redistributable (x64) - 12.0.30501" Size="7194312" Version="12.0.30501.0" />
-				<ExitCode Value="1638" Behavior="success"/> <!-- Don't fail if newer version is installed -->
-			</ExePackage>
-		</PackageGroup>
-	</Fragment>
-
-	<Fragment>
-		<util:RegistrySearch Root="HKLM"
-                     Key="SOFTWARE\Microsoft\VisualStudio\14.0\VC\Runtimes\x64"
-                     Variable="CPP2015Redist64"
-                     Value="Installed"
-                     Result="value"
-					 Win64="yes"/>
-		<util:RegistrySearch Root="HKLM"
-                     Key="SOFTWARE\Microsoft\VisualStudio\14.0\VC\Runtimes\x64"
-                     Variable="CPP2015Redist32"
-                     Value="Installed"
-                     Result="value"
-					 Win64="no"/>
-		<PackageGroup Id="redist_vc15">
-			<ExePackage Id="vc15" Cache="no" PerMachine="yes" Vital="yes" Compressed="no" Permanent="yes"
-				  Name="vc_redist.x64.exe"
-				  DownloadUrl="$(var.VC15RedistWebLink)"
-                  InstallCommand="/quiet /norestart"
-				  DetectCondition="(CPP2015Redist32) OR (CPP2015Redist64)">
-				<RemotePayload Description="Microsoft Visual C++ 2015 Redistributable (x64) - 14.0.23026" Hash="3155CB0F146B927FCC30647C1A904CD162548C8C"
-					ProductName="Microsoft Visual C++ 2015 Redistributable (x64) - 14.0.23026" Size="14572000" Version="14.0.23026.0" />
+				<RemotePayload Description="Microsoft Visual C++ 2013 Redistributable (x64) - 12.0.40660" Hash="261C2E77D288A513A9EB7849CF5AFCA6167D4FA2"
+					ProductName="Microsoft Visual C++ 2013 Redistributable (x64) - 12.0.40660" Size="7201032" Version="12.0.40660.0" />
 				<ExitCode Value="1638" Behavior="success"/> <!-- Don't fail if newer version is installed -->
 			</ExePackage>
 		</PackageGroup>
@@ -345,14 +308,18 @@
                      Value="Installed"
                      Result="value"
 					 Win64="no"/>
-		<PackageGroup Id="redist_vc17">
+		<PackageGroup Id="vc15to19">
 			<ExePackage Id="vc17" Cache="no" PerMachine="yes" Vital="yes" Compressed="no" Permanent="yes"
 				  Name="vc_redist.x64.exe"
-				  DownloadUrl="$(var.VC17RedistWebLink)"
+				  DownloadUrl="$(var.VC15to19RedistWebLink)"
                   InstallCommand="/quiet /norestart"
 				  DetectCondition="(CPP2017Redist32) OR (CPP2017Redist64)">
-				<RemotePayload Description="Microsoft Visual C++ 2017 Redistributable (x64) - 14.13.26020" Hash="5027E77B7EDEDA314287F9E2279C3927D92F6FF8"
-					ProductName="Microsoft Visual C++ 2017 Redistributable (x64) - 14.13.26020" Size="15301240" Version="14.13.26020.0" />
+				<RemotePayload 
+					Size="14882064"
+					Version="14.28.29914.0"
+					ProductName="Microsoft Visual C++ 2015-2019 Redistributable (x64) - 14.28.29914"
+					Description="Microsoft Visual C++ 2015-2019 Redistributable (x64) - 14.28.29914"
+					Hash="A4EFAD335D3CCFA19963F53398E87BE5C8BEBC45" />
 				<ExitCode Value="1638" Behavior="success"/> <!-- Don't fail if newer version is installed -->
 			</ExePackage>
 		</PackageGroup>

--- a/BaseInstallerBuild/OfflineBundle.wxs
+++ b/BaseInstallerBuild/OfflineBundle.wxs
@@ -139,29 +139,13 @@
 	<Fragment>
 		<util:RegistrySearch Root="HKLM"
                      Key="SOFTWARE\Microsoft\VisualStudio\14.0\VC\Runtimes\x86"
-                     Variable="CPP2015Redist"
-                     Value="Installed"
-                     Result="value"/>
-		<PackageGroup Id="redist_vc15">
-			<ExePackage Id="vc15" Cache="no" PerMachine="yes" Vital="yes" Compressed="yes" Permanent="yes"
-				  Name="vcredist_x86.exe"
-				  SourceFile="..\libs\vcredist_2015_x86.exe"
-                  InstallCommand="/quiet /norestart"
-				  DetectCondition="CPP2015Redist">
-				<ExitCode Value="1638" Behavior="success"/> <!-- Don't fail if newer version is installed -->
-			</ExePackage>
-		</PackageGroup>
-	</Fragment>
-	<Fragment>
-		<util:RegistrySearch Root="HKLM"
-                     Key="SOFTWARE\Microsoft\VisualStudio\14.0\VC\Runtimes\x86"
                      Variable="CPP2017Redist"
                      Value="Installed"
                      Result="value"/>
-		<PackageGroup Id="redist_vc17">
+		<PackageGroup Id="redist_vc15to19">
 			<ExePackage Id="vc17" Cache="no" PerMachine="yes" Vital="yes" Compressed="yes" Permanent="yes"
 				  Name="vcredist_x86.exe"
-				  SourceFile="..\libs\vcredist_2017_x86.exe"
+				  SourceFile="..\libs\vcredist_2015-19_x86.exe"
                   InstallCommand="/quiet /norestart"
 				  DetectCondition="CPP2017Redist">
 				 <ExitCode Value="1638" Behavior="success"/> <!-- Don't fail if newer version is installed -->
@@ -254,28 +238,6 @@
 	<Fragment>
 		<util:RegistrySearch Root="HKLM"
                      Key="SOFTWARE\Microsoft\VisualStudio\14.0\VC\Runtimes\x64"
-                     Variable="CPP2015Redist64"
-                     Value="Installed"
-                     Result="value"
-					 Win64="yes"/>
-		<util:RegistrySearch Root="HKLM"
-                     Key="SOFTWARE\Microsoft\VisualStudio\14.0\VC\Runtimes\x64"
-                     Variable="CPP2015Redist32"
-                     Value="Installed"
-                     Result="value"
-					 Win64="no"/>
-		<PackageGroup Id="redist_vc15">
-			<ExePackage Id="vc15" Cache="no" PerMachine="yes" Vital="yes" Compressed="yes" Permanent="yes"
-                  SourceFile="..\libs\vcredist_2015_x64.exe"
-                  InstallCommand="/quiet /norestart"
-				  DetectCondition="(CPP2015Redist32) OR (CPP2015Redist64)">
-				<ExitCode Value="1638" Behavior="success"/> <!-- Don't fail if newer version is installed -->
-			</ExePackage>
-		</PackageGroup>
-	</Fragment>
-	<Fragment>
-		<util:RegistrySearch Root="HKLM"
-                     Key="SOFTWARE\Microsoft\VisualStudio\14.0\VC\Runtimes\x64"
                      Variable="CPP2017Redist64"
                      Value="Installed"
                      Result="value"
@@ -286,9 +248,9 @@
                      Value="Installed"
                      Result="value"
 					 Win64="no"/>
-		<PackageGroup Id="redist_vc17">
+		<PackageGroup Id="redist_vc15to19">
 			<ExePackage Id="vc17" Cache="no" PerMachine="yes" Vital="yes" Compressed="yes" Permanent="yes"
-                  SourceFile="..\libs\vcredist_2017_x64.exe"
+                  SourceFile="..\libs\vcredist_2015-19_x64.exe"
                   InstallCommand="/quiet /norestart"
 				  DetectCondition="(CPP2017Redist32) OR (CPP2017Redist64)">
 				<ExitCode Value="1638" Behavior="success"/> <!-- Don't fail if newer version is installed -->


### PR DESCRIPTION
* Update the information in the 64bit VC++ 2008 download
  Fixes LT-20585
* Add instructions for generating the information with heat
* Update the VS 2013 64bit redistributables to the latest version
* Update the VS 2015-19 redistributables to the latest versions
* Drop the separate VS 2015 redistributables

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/genericinstaller/60)
<!-- Reviewable:end -->
