### PR TITLE
Build ProcRunner

### DIFF
--- a/BaseInstallerBuild/Framework.wxs
+++ b/BaseInstallerBuild/Framework.wxs
@@ -226,7 +226,7 @@
 				<Directory Id='CompanyCommonFilesFolder' Name='$(var.SafeManufacturer)'>
 					<Component Id='ProcRunner' Guid='*' Permanent='yes' UninstallWhenSuperseded='yes' NeverOverwrite='no'>
 						<File Id='ProcRunnerFile' Name='ProcRunner_5.0.exe'
-							Source='../ProcRunner/ProcRunner/bin/Release/ProcRunner_5.0.exe' KeyPath='yes'/>
+							Source='../ProcRunner/ProcRunner/bin/Release/net48/ProcRunner_5.0.exe' KeyPath='yes'/>
 					</Component>
 				</Directory>
 			</Directory>

--- a/BaseInstallerBuild/buildBaseInstaller.bat
+++ b/BaseInstallerBuild/buildBaseInstaller.bat
@@ -43,8 +43,16 @@ REM Ensure WiX tools are on the PATH
 where heat >nul 2>nul
 if not %errorlevel% == 0 set PATH=%WIX%/bin;%PATH%
 
+rem TODO (Hasso) 2021.07: figure out how to do this without breaking the build:
+rem if  "%msbuild%" == "" ( set msbuild=msbuild )
+
 (
 	@echo on
+	@REM CustomActions are built by WiX magic; ProcRunner must be built normally.
+	@REM Although there are no NuGet packages to restore, the Restore target is required to generate project.assets.json
+	%msbuild% ../ProcRunner/ProcRunner.sln /p:Configuration=Release /t:Restore;Rebuild
+
+) && (
 	@REM Harvest (heat) the application and data files.
 	heat.exe dir %MASTERBUILDDIR% -cg HarvestedAppFiles -gg -scom -sreg -sfrag -srd -sw5150 -sw5151 -dr APPFOLDER -var var.MASTERBUILDDIR -t KeyPathFix.xsl -out AppHarvest.wxs
 	heat.exe dir %MASTERDATADIR% -cg HarvestedDataFiles -gg -scom -sreg -sfrag -srd -sw5150 -sw5151 -dr HARVESTDATAFOLDER -var var.MASTERDATADIR -t KeyPathFix.xsl -out DataHarvest.wxs

--- a/CreateUpdatePatch/AppNoUi.wxs
+++ b/CreateUpdatePatch/AppNoUi.wxs
@@ -87,7 +87,7 @@
 				<Directory Id='CompanyCommonFilesFolder' Name='$(var.SafeManufacturer)'>
 					<Component Id='ProcRunner' Guid='*' Permanent='yes' UninstallWhenSuperseded='yes' NeverOverwrite='no'>
 						<File Id='ProcRunnerFile' Name='ProcRunner_5.0.exe'
-							Source='../ProcRunner/ProcRunner/bin/$(sys.BUILDARCH)/Release/ProcRunner_5.0.exe' KeyPath='yes'/>
+							Source='../ProcRunner/ProcRunner/bin/$(sys.BUILDARCH)/Release/net48/ProcRunner_5.0.exe' KeyPath='yes'/>
 					</Component>
 				</Directory>
 			</Directory>


### PR DESCRIPTION
CustomActions.dll is not built in local install builds, but the build server builds it through some unknown magic.
ProcRunner is not built by this magic, so it has to be built explicitly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/genericinstaller/65)
<!-- Reviewable:end -->
