### PR TITLE
LT-21006: Ignore misarchitectured redistributables

### DIFF
--- a/BaseInstallerBuild/Bundle.wxs
+++ b/BaseInstallerBuild/Bundle.wxs
@@ -238,24 +238,12 @@
 					Value="Present"
 					Result="value"
 					Win64="yes"/>
-		<util:RegistrySearch Root="HKLM"
-					Key="SOFTWARE\Microsoft\VisualStudio\10.0\VC\VCRedist\x64"
-					Variable="CPP2010Redist32"
-					Value="Installed"
-					Result="value"
-					Win64="no"/>
-		<util:RegistrySearch Root="HKLM"
-					Key="SOFTWARE\Microsoft\VisualStudio\10.0\VC\VCRedist\x64\KB2565063"
-					Variable="CPP2010Redist32Security"
-					Value="Present"
-					Result="value"
-					Win64="no"/>
 		<PackageGroup Id="redist_vc10">
 			<ExePackage Id="vc10" Cache="no" PerMachine="yes" Vital="yes" Compressed="no" Permanent="yes"
 					Name="vcredist_x64.exe"
 					DownloadUrl="$(var.VC10RedistWebLink)"
 					InstallCommand="/quiet /norestart"
-					DetectCondition="(CPP2010Redist32 AND CPP2010Redist32Security) OR (CPP2010Redist64 AND CPP2010Redist64Security)">
+					DetectCondition="CPP2010Redist64 AND CPP2010Redist64Security">
 				<RemotePayload Description="Microsoft Visual C++ 2010 x64 Redistributable Setup" Hash="8691972F0A5BF919701AC3B80FB693FC715420C2"
 					ProductName="Microsoft Visual C++ 2010 x64 Redistributable" Size="10274136" Version="10.0.40219.325" />
 				<ExitCode Value="1638" Behavior="success"/> <!-- Don't fail if newer version is installed -->
@@ -269,18 +257,12 @@
 					Value="Installed"
 					Result="value"
 					Win64="yes"/>
-		<util:RegistrySearch Root="HKLM"
-					Key="SOFTWARE\Microsoft\VisualStudio\11.0\VC\Runtimes\x64"
-					Variable="CPP2012Redist32"
-					Value="Installed"
-					Result="value"
-					Win64="no"/>
 		<PackageGroup Id="redist_vc11">
 			<ExePackage Id="vc11" Cache="no" PerMachine="yes" Vital="yes" Compressed="no" Permanent="yes"
 					Name="vcredist_x64.exe"
 					DownloadUrl="$(var.VC11RedistWebLink)"
 					InstallCommand="/quiet /norestart"
-					DetectCondition="(CPP2012Redist32) OR (CPP2012Redist64)">
+					DetectCondition="CPP2012Redist64">
 				<RemotePayload Description="Microsoft Visual C++ 2012 Redistributable (x64) - 11.0.61030" Hash="1A5D93DDDBC431AB27B1DA711CD3370891542797"
 					ProductName="Microsoft Visual C++ 2012 Redistributable (x64) - 11.0.61030" Size="7186992" Version="11.0.61030.0" />
 				<ExitCode Value="1638" Behavior="success"/> <!-- Don't fail if newer version is installed -->
@@ -294,18 +276,12 @@
 					Value="Installed"
 					Result="value"
 					Win64="yes"/>
-		<util:RegistrySearch Root="HKLM"
-					Key="SOFTWARE\Microsoft\VisualStudio\12.0\VC\Runtimes\x64"
-					Variable="CPP2013Redist32"
-					Value="Installed"
-					Result="value"
-					Win64="no"/>
 		<PackageGroup Id="redist_vc12">
 			<ExePackage Id="vc12" Cache="no" PerMachine="yes" Vital="yes" Compressed="no" Permanent="yes"
 					Name="vcredist_x64.exe"
 					DownloadUrl="$(var.VC12RedistWebLink)"
 					InstallCommand="/quiet /norestart"
-					DetectCondition="(CPP2013Redist32) OR (CPP2013Redist64)">
+					DetectCondition="CPP2013Redist64">
 				<RemotePayload Description="Microsoft Visual C++ 2013 Redistributable (x64) - 12.0.40660" Hash="261C2E77D288A513A9EB7849CF5AFCA6167D4FA2"
 					ProductName="Microsoft Visual C++ 2013 Redistributable (x64) - 12.0.40660" Size="7201032" Version="12.0.40660.0" />
 				<ExitCode Value="1638" Behavior="success"/> <!-- Don't fail if newer version is installed -->
@@ -319,18 +295,12 @@
 					Value="Installed"
 					Result="value"
 					Win64="yes"/>
-		<util:RegistrySearch Root="HKLM"
-					Key="SOFTWARE\Microsoft\VisualStudio\14.0\VC\Runtimes\X64"
-					Variable="CPP2017Redist32"
-					Value="Installed"
-					Result="value"
-					Win64="no"/>
 		<PackageGroup Id="redist_vc15to19">
 			<ExePackage Id="vc17" Cache="no" PerMachine="yes" Vital="yes" Compressed="no" Permanent="yes"
 					Name="vc_redist.x64.exe"
 					DownloadUrl="$(var.VC15to19RedistWebLink)"
 					InstallCommand="/quiet /norestart"
-					DetectCondition="(CPP2017Redist32) OR (CPP2017Redist64)">
+					DetectCondition="CPP2017Redist64">
 				<RemotePayload 
 					Size="25169400"
 					Version="14.29.30040.0"

--- a/BaseInstallerBuild/OfflineBundle.wxs
+++ b/BaseInstallerBuild/OfflineBundle.wxs
@@ -187,23 +187,11 @@
 					Value="Present"
 					Result="value"
 					Win64="yes"/>
-		<util:RegistrySearch Root="HKLM"
-					Key="SOFTWARE\Microsoft\VisualStudio\10.0\VC\VCRedist\x64"
-					Variable="CPP2010Redist32"
-					Value="Installed"
-					Result="value"
-					Win64="no"/>
-		<util:RegistrySearch Root="HKLM"
-					Key="SOFTWARE\Microsoft\VisualStudio\10.0\VC\VCRedist\x64\KB2565063"
-					Variable="CPP2010Redist32Security"
-					Value="Present"
-					Result="value"
-					Win64="no"/>
 		<PackageGroup Id="redist_vc10">
 			<ExePackage Id="vc10" Cache="no" PerMachine="yes" Vital="yes" Compressed="yes" Permanent="yes"
 				SourceFile="..\libs\vcredist_2010_x64.exe"
 				InstallCommand="/quiet /norestart"
-				DetectCondition="(CPP2010Redist32 AND CPP2010Redist32Security) OR (CPP2010Redist64 AND CPP2010Redist64Security)">
+				DetectCondition="CPP2010Redist64 AND CPP2010Redist64Security">
 				<ExitCode Value="1638" Behavior="success"/> <!-- Don't fail if newer version is installed -->
 			</ExePackage>
 		</PackageGroup>
@@ -215,17 +203,11 @@
 					Value="Installed"
 					Result="value"
 					Win64="yes"/>
-		<util:RegistrySearch Root="HKLM"
-					Key="SOFTWARE\Microsoft\VisualStudio\11.0\VC\Runtimes\x64"
-					Variable="CPP2012Redist32"
-					Value="Installed"
-					Result="value"
-					Win64="no"/>
 		<PackageGroup Id="redist_vc11">
 			<ExePackage Id="vc11" Cache="no" PerMachine="yes" Vital="yes" Compressed="yes" Permanent="yes"
 				SourceFile="..\libs\vcredist_2012_x64.exe"
 				InstallCommand="/quiet /norestart"
-				DetectCondition="(CPP2012Redist32) OR (CPP2012Redist64)">
+				DetectCondition="CPP2012Redist64">
 				<ExitCode Value="1638" Behavior="success"/> <!-- Don't fail if newer version is installed -->
 			</ExePackage>
 		</PackageGroup>
@@ -237,17 +219,11 @@
 					Value="Installed"
 					Result="value"
 					Win64="yes"/>
-		<util:RegistrySearch Root="HKLM"
-					Key="SOFTWARE\Microsoft\VisualStudio\12.0\VC\Runtimes\x64"
-					Variable="CPP2013Redist32"
-					Value="Installed"
-					Result="value"
-					Win64="no"/>
 		<PackageGroup Id="redist_vc12">
 			<ExePackage Id="vc12" Cache="no" PerMachine="yes" Vital="yes" Compressed="yes" Permanent="yes"
 				SourceFile="..\libs\vcredist_2013_x64.exe"
 				InstallCommand="/quiet /norestart"
-				DetectCondition="(CPP2013Redist32) OR (CPP2013Redist64)">
+				DetectCondition="CPP2013Redist64">
 				<ExitCode Value="1638" Behavior="success"/> <!-- Don't fail if newer version is installed -->
 			</ExePackage>
 		</PackageGroup>
@@ -259,17 +235,11 @@
 					Value="Installed"
 					Result="value"
 					Win64="yes"/>
-		<util:RegistrySearch Root="HKLM"
-					Key="SOFTWARE\Microsoft\VisualStudio\14.0\VC\Runtimes\X64"
-					Variable="CPP2017Redist32"
-					Value="Installed"
-					Result="value"
-					Win64="no"/>
 		<PackageGroup Id="redist_vc15to19">
 			<ExePackage Id="vc17" Cache="no" PerMachine="yes" Vital="yes" Compressed="yes" Permanent="yes"
 				SourceFile="..\libs\vcredist_2015-19_x64.exe"
 				InstallCommand="/quiet /norestart"
-				DetectCondition="(CPP2017Redist32) OR (CPP2017Redist64)">
+				DetectCondition="CPP2017Redist64">
 				<ExitCode Value="1638" Behavior="success"/> <!-- Don't fail if newer version is installed -->
 			</ExePackage>
 		</PackageGroup>


### PR DESCRIPTION
Install 64-bit redistributables for all requested versions that are not already installed for 64-bit. Ignore 32-bit redistributables.

This fixes https://jira.sil.org/browse/LT-21006