### PR TITLE
Revert "LT-21006: Ignore misarched redistributables (#70)"

### DIFF
--- a/BaseInstallerBuild/Bundle.wxs
+++ b/BaseInstallerBuild/Bundle.wxs
@@ -206,6 +206,8 @@
 	<?define VC11RedistWebLink = https://download.microsoft.com/download/1/6/B/16B06F60-3B20-4FF2-B699-5E9B7962F9AE/VSU_4/vcredist_x64.exe ?>
 	<?define VC12RedistWebLink = https://download.microsoft.com/download/0/5/6/056DCDA9-D667-4E27-8001-8A0C6971D6B1/vcredist_x64.exe ?>
 	<?define VC15to19RedistWebLink = https://download.visualstudio.microsoft.com/download/pr/36e45907-8554-4390-ba70-9f6306924167/97CC5066EB3C7246CF89B735AE0F5A5304A7EE33DC087D65D9DFF3A1A73FE803/VC_redist.x64.exe ?>
+	<!-- Some 64-bit runtimes register themselves in the 32-bit space. Check for Runtimes\X64 or similar under each space;
+		if either exists, the 64-bit redistributable is installed. -->
 	<Fragment>
 		<util:RegistrySearch Root="HKLM"
 					Key="Software\Microsoft\Windows\CurrentVersion\Uninstall\{5FCE6D76-F5DC-37AB-B2B8-22AB8CEDB1D4}"
@@ -238,12 +240,24 @@
 					Value="Present"
 					Result="value"
 					Win64="yes"/>
+		<util:RegistrySearch Root="HKLM"
+					Key="SOFTWARE\Microsoft\VisualStudio\10.0\VC\VCRedist\x64"
+					Variable="CPP2010Redist32"
+					Value="Installed"
+					Result="value"
+					Win64="no"/>
+		<util:RegistrySearch Root="HKLM"
+					Key="SOFTWARE\Microsoft\VisualStudio\10.0\VC\VCRedist\x64\KB2565063"
+					Variable="CPP2010Redist32Security"
+					Value="Present"
+					Result="value"
+					Win64="no"/>
 		<PackageGroup Id="redist_vc10">
 			<ExePackage Id="vc10" Cache="no" PerMachine="yes" Vital="yes" Compressed="no" Permanent="yes"
 					Name="vcredist_x64.exe"
 					DownloadUrl="$(var.VC10RedistWebLink)"
 					InstallCommand="/quiet /norestart"
-					DetectCondition="CPP2010Redist64 AND CPP2010Redist64Security">
+					DetectCondition="(CPP2010Redist32 AND CPP2010Redist32Security) OR (CPP2010Redist64 AND CPP2010Redist64Security)">
 				<RemotePayload Description="Microsoft Visual C++ 2010 x64 Redistributable Setup" Hash="8691972F0A5BF919701AC3B80FB693FC715420C2"
 					ProductName="Microsoft Visual C++ 2010 x64 Redistributable" Size="10274136" Version="10.0.40219.325" />
 				<ExitCode Value="1638" Behavior="success"/> <!-- Don't fail if newer version is installed -->
@@ -257,12 +271,18 @@
 					Value="Installed"
 					Result="value"
 					Win64="yes"/>
+		<util:RegistrySearch Root="HKLM"
+					Key="SOFTWARE\Microsoft\VisualStudio\11.0\VC\Runtimes\x64"
+					Variable="CPP2012Redist32"
+					Value="Installed"
+					Result="value"
+					Win64="no"/>
 		<PackageGroup Id="redist_vc11">
 			<ExePackage Id="vc11" Cache="no" PerMachine="yes" Vital="yes" Compressed="no" Permanent="yes"
 					Name="vcredist_x64.exe"
 					DownloadUrl="$(var.VC11RedistWebLink)"
 					InstallCommand="/quiet /norestart"
-					DetectCondition="CPP2012Redist64">
+					DetectCondition="(CPP2012Redist32) OR (CPP2012Redist64)">
 				<RemotePayload Description="Microsoft Visual C++ 2012 Redistributable (x64) - 11.0.61030" Hash="1A5D93DDDBC431AB27B1DA711CD3370891542797"
 					ProductName="Microsoft Visual C++ 2012 Redistributable (x64) - 11.0.61030" Size="7186992" Version="11.0.61030.0" />
 				<ExitCode Value="1638" Behavior="success"/> <!-- Don't fail if newer version is installed -->
@@ -276,12 +296,18 @@
 					Value="Installed"
 					Result="value"
 					Win64="yes"/>
+		<util:RegistrySearch Root="HKLM"
+					Key="SOFTWARE\Microsoft\VisualStudio\12.0\VC\Runtimes\x64"
+					Variable="CPP2013Redist32"
+					Value="Installed"
+					Result="value"
+					Win64="no"/>
 		<PackageGroup Id="redist_vc12">
 			<ExePackage Id="vc12" Cache="no" PerMachine="yes" Vital="yes" Compressed="no" Permanent="yes"
 					Name="vcredist_x64.exe"
 					DownloadUrl="$(var.VC12RedistWebLink)"
 					InstallCommand="/quiet /norestart"
-					DetectCondition="CPP2013Redist64">
+					DetectCondition="(CPP2013Redist32) OR (CPP2013Redist64)">
 				<RemotePayload Description="Microsoft Visual C++ 2013 Redistributable (x64) - 12.0.40660" Hash="261C2E77D288A513A9EB7849CF5AFCA6167D4FA2"
 					ProductName="Microsoft Visual C++ 2013 Redistributable (x64) - 12.0.40660" Size="7201032" Version="12.0.40660.0" />
 				<ExitCode Value="1638" Behavior="success"/> <!-- Don't fail if newer version is installed -->
@@ -295,12 +321,18 @@
 					Value="Installed"
 					Result="value"
 					Win64="yes"/>
+		<util:RegistrySearch Root="HKLM"
+					Key="SOFTWARE\Microsoft\VisualStudio\14.0\VC\Runtimes\X64"
+					Variable="CPP2017Redist32"
+					Value="Installed"
+					Result="value"
+					Win64="no"/>
 		<PackageGroup Id="redist_vc15to19">
 			<ExePackage Id="vc17" Cache="no" PerMachine="yes" Vital="yes" Compressed="no" Permanent="yes"
 					Name="vc_redist.x64.exe"
 					DownloadUrl="$(var.VC15to19RedistWebLink)"
 					InstallCommand="/quiet /norestart"
-					DetectCondition="CPP2017Redist64">
+					DetectCondition="(CPP2017Redist32) OR (CPP2017Redist64)">
 				<RemotePayload 
 					Size="25169400"
 					Version="14.29.30040.0"

--- a/BaseInstallerBuild/OfflineBundle.wxs
+++ b/BaseInstallerBuild/OfflineBundle.wxs
@@ -158,6 +158,8 @@
 		</PackageGroup>
 	</Fragment>
 	<?elseif $(sys.BUILDARCH)="x64"?>
+	<!-- Some 64-bit runtimes register themselves in the 32-bit space.
+		Check for Runtimes\X64 or similar under each space; if either exists, the 64-bit redistributable is installed. -->
 	<Fragment>
 		<util:RegistrySearch Root="HKLM"
 					Key="Software\Microsoft\Windows\CurrentVersion\Uninstall\{5FCE6D76-F5DC-37AB-B2B8-22AB8CEDB1D4}"
@@ -187,11 +189,23 @@
 					Value="Present"
 					Result="value"
 					Win64="yes"/>
+		<util:RegistrySearch Root="HKLM"
+					Key="SOFTWARE\Microsoft\VisualStudio\10.0\VC\VCRedist\x64"
+					Variable="CPP2010Redist32"
+					Value="Installed"
+					Result="value"
+					Win64="no"/>
+		<util:RegistrySearch Root="HKLM"
+					Key="SOFTWARE\Microsoft\VisualStudio\10.0\VC\VCRedist\x64\KB2565063"
+					Variable="CPP2010Redist32Security"
+					Value="Present"
+					Result="value"
+					Win64="no"/>
 		<PackageGroup Id="redist_vc10">
 			<ExePackage Id="vc10" Cache="no" PerMachine="yes" Vital="yes" Compressed="yes" Permanent="yes"
 				SourceFile="..\libs\vcredist_2010_x64.exe"
 				InstallCommand="/quiet /norestart"
-				DetectCondition="CPP2010Redist64 AND CPP2010Redist64Security">
+				DetectCondition="(CPP2010Redist32 AND CPP2010Redist32Security) OR (CPP2010Redist64 AND CPP2010Redist64Security)">
 				<ExitCode Value="1638" Behavior="success"/> <!-- Don't fail if newer version is installed -->
 			</ExePackage>
 		</PackageGroup>
@@ -203,11 +217,17 @@
 					Value="Installed"
 					Result="value"
 					Win64="yes"/>
+		<util:RegistrySearch Root="HKLM"
+					Key="SOFTWARE\Microsoft\VisualStudio\11.0\VC\Runtimes\x64"
+					Variable="CPP2012Redist32"
+					Value="Installed"
+					Result="value"
+					Win64="no"/>
 		<PackageGroup Id="redist_vc11">
 			<ExePackage Id="vc11" Cache="no" PerMachine="yes" Vital="yes" Compressed="yes" Permanent="yes"
 				SourceFile="..\libs\vcredist_2012_x64.exe"
 				InstallCommand="/quiet /norestart"
-				DetectCondition="CPP2012Redist64">
+				DetectCondition="(CPP2012Redist32) OR (CPP2012Redist64)">
 				<ExitCode Value="1638" Behavior="success"/> <!-- Don't fail if newer version is installed -->
 			</ExePackage>
 		</PackageGroup>
@@ -219,11 +239,17 @@
 					Value="Installed"
 					Result="value"
 					Win64="yes"/>
+		<util:RegistrySearch Root="HKLM"
+					Key="SOFTWARE\Microsoft\VisualStudio\12.0\VC\Runtimes\x64"
+					Variable="CPP2013Redist32"
+					Value="Installed"
+					Result="value"
+					Win64="no"/>
 		<PackageGroup Id="redist_vc12">
 			<ExePackage Id="vc12" Cache="no" PerMachine="yes" Vital="yes" Compressed="yes" Permanent="yes"
 				SourceFile="..\libs\vcredist_2013_x64.exe"
 				InstallCommand="/quiet /norestart"
-				DetectCondition="CPP2013Redist64">
+				DetectCondition="(CPP2013Redist32) OR (CPP2013Redist64)">
 				<ExitCode Value="1638" Behavior="success"/> <!-- Don't fail if newer version is installed -->
 			</ExePackage>
 		</PackageGroup>
@@ -235,11 +261,17 @@
 					Value="Installed"
 					Result="value"
 					Win64="yes"/>
+		<util:RegistrySearch Root="HKLM"
+					Key="SOFTWARE\Microsoft\VisualStudio\14.0\VC\Runtimes\X64"
+					Variable="CPP2017Redist32"
+					Value="Installed"
+					Result="value"
+					Win64="no"/>
 		<PackageGroup Id="redist_vc15to19">
 			<ExePackage Id="vc17" Cache="no" PerMachine="yes" Vital="yes" Compressed="yes" Permanent="yes"
 				SourceFile="..\libs\vcredist_2015-19_x64.exe"
 				InstallCommand="/quiet /norestart"
-				DetectCondition="CPP2017Redist64">
+				DetectCondition="(CPP2017Redist32) OR (CPP2017Redist64)">
 				<ExitCode Value="1638" Behavior="success"/> <!-- Don't fail if newer version is installed -->
 			</ExePackage>
 		</PackageGroup>


### PR DESCRIPTION
And add a comment about why we check two places.

This is what I get for not reading carefully. The 32 and 64 checks
are both for 64-bit redistributables (key ends in x64) but look in
the 32- and 64-bit registry spaces (Win64="yes" or "no" to determine
whether to look under WOW6432Node). Versions 10-12 register
themselves only in the 32-bit space; Version 14 registers itself in
both. Always checking both spaces seems to be the most robust thing
to do.

This reverts commit 533d7eeb33a0414b36125cc2d2befaae28db7e45.

Change-Id: I3047fa33906d66fe0cce70cf567229f6f110a2c9

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/genericinstaller/71)
<!-- Reviewable:end -->
