### PR TITLE
Move several properties to Directory.Build.props

### DIFF
--- a/BaseInstallerBuild/Framework.wxs
+++ b/BaseInstallerBuild/Framework.wxs
@@ -222,7 +222,7 @@
 				<Directory Id='CompanyCommonFilesFolder' Name='$(var.SafeManufacturer)'>
 					<Component Id='ProcRunner' Guid='*' Permanent='yes' UninstallWhenSuperseded='yes' NeverOverwrite='no'>
 						<File Id='ProcRunnerFile' Name='ProcRunner_5.0.exe'
-							Source='../ProcRunner/ProcRunner/bin/Release/net48/ProcRunner_5.0.exe' KeyPath='yes'/>
+							Source='../ProcRunner/ProcRunner/bin/Release/ProcRunner_5.0.exe' KeyPath='yes'/>
 					</Component>
 				</Directory>
 			</Directory>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,16 @@
+<Project>
+	<PropertyGroup>
+		<TargetFramework>net48</TargetFramework>
+		<TargetFrameworks>$(TargetFramework)</TargetFrameworks>
+		<Company>SIL International</Company>
+		<Authors>SIL International</Authors>
+		<Copyright>Copyright © 2016-2023 SIL International</Copyright>
+		<OutputPath>bin/$(Configuration)</OutputPath>
+		<TargetDir>$(OutputPath)</TargetDir>
+		<AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+		<AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
+		<LangVersion>8</LangVersion>
+		<AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+		<GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+	</PropertyGroup>
+</Project>

--- a/ProcRunner/ProcRunner/ProcRunner.csproj
+++ b/ProcRunner/ProcRunner/ProcRunner.csproj
@@ -1,12 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net48</TargetFramework>
-    <Company>SIL International</Company>
-    <Copyright>"Copyright (c) 2016-2021 SIL International"</Copyright>
     <AssemblyName>ProcRunner_5.0</AssemblyName>
     <Version>5.0.0</Version>
-    <Description>ProcRunner runs an installer and then restarts the application so that running processes do not block the installer from updating files.
-</Description>
+    <Description>ProcRunner runs an installer and then restarts the application so that running processes do not block the installer from updating files.</Description>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
to supersede client repositories' Directory.Build.props and ensure consistent builds of CustomActions and ProcRunner

Change-Id: I04b689aed1ab5249915b4b875d285ce190315fe5

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/genericinstaller/74)
<!-- Reviewable:end -->
