### PR TITLE
Removed duplicate NetFx48* definitions

### DIFF
--- a/BaseInstallerBuild/Bundle.wxs
+++ b/BaseInstallerBuild/Bundle.wxs
@@ -41,42 +41,6 @@
 			</MsiPackage>
 		</PackageGroup>
 	</Fragment>
-	<!-- .NET 4.8 -->
-	<?define NetFx48MinRelease = 528049 ?>
-	<?define NetFx48WebLink = https://download.visualstudio.microsoft.com/download/pr/2d6bb6b2-226a-4baa-bdec-798822606ff1/9b7b8746971ed51a1770ae4293618187/ndp48-web.exe ?>
-
-	<Fragment>
-		<util:RegistrySearch Root="HKLM" Key="SOFTWARE\Microsoft\Net Framework Setup\NDP\v4\Full" Value="Release" Variable="Netfx4FullRelease" />
-		<util:RegistrySearch Root="HKLM" Key="SOFTWARE\Microsoft\Net Framework Setup\NDP\v4\Full" Value="Release" Variable="Netfx4x64FullRelease" Win64="yes" />
-		<WixVariable Id="NetFx48OrLaterDetectCondition" Overridable="yes"
-		  Value="(Netfx4FullRelease &gt;= $(var.NetFx48MinRelease)) AND (NOT VersionNT64 OR (Netfx4x64FullRelease &gt;= $(var.NetFx48MinRelease)))" />
-		<WixVariable Id="NetFx48WebInstallCondition" Value="" Overridable="yes" />
-		<WixVariable Id="NetFx48WebPackageDirectory" Value="redist\" Overridable="yes" />
-
-		<PackageGroup Id="NetFx48Web">
-		  <ExePackage Id="NetFx48Web"
-			  InstallCommand="/q /norestart /ChainingPackage &quot;[WixBundleName]&quot; /log &quot;[NetFx48FullLog].html&quot;"
-			  RepairCommand="/q /norestart /repair /ChainingPackage &quot;[WixBundleName]&quot; /log &quot;[NetFx48FullLog].html&quot;"
-			  UninstallCommand="/uninstall /q /norestart /ChainingPackage &quot;[WixBundleName]&quot; /log &quot;[NetFx48FullLog].html&quot;"
-			  PerMachine="yes"
-			  DetectCondition="!(wix.NetFx48OrLaterDetectCondition)"
-			  InstallCondition="!(wix.NetFx48WebInstallCondition)"
-			  Vital="yes"
-			  Permanent="yes"
-			  Protocol="netfx4"
-			  DownloadUrl="$(var.NetFx48WebLink)"
-			  LogPathVariable="NetFx48FullLog"
-			  Compressed="no"
-			  Name="!(wix.NetFx48WebPackageDirectory)ndp48-web.exe">
-			<RemotePayload
-			  Description="Microsoft .NET Framework 4.8 Setup"
-			  Hash="4181398AA1FD5190155AC3A388434E5F7EA0B667"
-			  ProductName="Microsoft .NET Framework 4.8"
-			  Size="1439328"
-			  Version="4.8.3928.0" />
-		  </ExePackage>
-		</PackageGroup>
-	</Fragment>
 
 	<?if $(sys.BUILDARCH)="x86"?>
 	<!-- 32bit VC++ redistributable download section -->

--- a/BaseInstallerBuild/OfflineBundle.wxs
+++ b/BaseInstallerBuild/OfflineBundle.wxs
@@ -42,36 +42,6 @@
 		</PackageGroup>
 	</Fragment>
 	<!-- .NET 4.8 -->
-	<?define NetFx48MinRelease = 528049 ?>
-	<Fragment>
-		<util:RegistrySearch Root="HKLM" Key="SOFTWARE\Microsoft\Net Framework Setup\NDP\v4\Full" Value="Release" Variable="Netfx4FullRelease" />
-		<util:RegistrySearch Root="HKLM" Key="SOFTWARE\Microsoft\Net Framework Setup\NDP\v4\Full" Value="Release" Variable="Netfx4x64FullRelease" Win64="yes" />
-		<WixVariable Id="NetFx48OrLaterDetectCondition" Overridable="yes"
-		  Value="(Netfx4FullRelease &gt;= $(var.NetFx48MinRelease)) AND (NOT VersionNT64 OR (Netfx4x64FullRelease &gt;= $(var.NetFx48MinRelease)))" />
-		<WixVariable Id="NetFx48RedistInstallCondition" Value="" Overridable="yes" />
-
-		<PackageGroup Id="NetFx48Redist">
-		  <ExePackage Id="NetFx48Redist"
-			  InstallCommand="/q /norestart /ChainingPackage &quot;[WixBundleName]&quot; /log &quot;[NetFx48FullLog].html&quot;"
-			  RepairCommand="/q /norestart /repair /ChainingPackage &quot;[WixBundleName]&quot; /log &quot;[NetFx48FullLog].html&quot;"
-			  UninstallCommand="/uninstall /q /norestart /ChainingPackage &quot;[WixBundleName]&quot; /log &quot;[NetFx48FullLog].html&quot;"
-			  PerMachine="yes"
-			  DetectCondition="!(wix.NetFx48OrLaterDetectCondition)"
-			  InstallCondition="!(wix.NetFx48RedistInstallCondition)"
-			  Vital="yes"
-			  Permanent="yes"
-			  Protocol="netfx4"
-			  LogPathVariable="NetFx48FullLog"
-			  Compressed="yes"
-			  SourceFile="..\libs\ndp48-x86-x64-allos-enu.exe">
-			<ExitCode Behavior="forceReboot" Value="1641" />
-			<ExitCode Behavior="forceReboot" Value="3010" />
-			<ExitCode Behavior="error" Value="5100" />
-			<ExitCode Behavior="error" Value="1603" />
-			<ExitCode Behavior="success" Value="0" />
-		  </ExePackage>
-		</PackageGroup>
-	</Fragment>
 	<?if $(sys.BUILDARCH)="x86"?>
 	<Fragment>
 	<Property Id="CRVSINSTALLED">


### PR DESCRIPTION
These were necessary for Wix 3.11, since it didn't include those, but with Wix 3.14, these two ID's already exist. This is necessary for the build servers, which are using v3.14

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/genericinstaller/79)
<!-- Reviewable:end -->
