### PR TITLE
Allow harvest exclude, ComponentRef strip, light -fv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ CreateUpdatePatch/Master/
 CreateUpdatePatch/Update/
 obj/
 .vs/
+
+# Generated from heat-exclude.xml.template by buildMsi.bat, or overwritten by product builds (e.g. FieldWorks).
+BaseInstallerBuild/heat-exclude.xml

--- a/BaseInstallerBuild/KeyPathFix.xsl
+++ b/BaseInstallerBuild/KeyPathFix.xsl
@@ -1,7 +1,7 @@
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:my="http://schema.infor.com/InforOAGIS/2">
 	<xsl:output method="xml" version="1.0" encoding="UTF-8" indent="yes" />
 
-	<xsl:template match="@*|node()">
+	<xsl:template match="@*|node()" priority="-1">
 		<xsl:copy>
 			<xsl:apply-templates select="@*|node()"/>
 		</xsl:copy>
@@ -14,5 +14,80 @@
 		<xsl:attribute name="KeyPath">
 			<xsl:value-of select="'no'"/>
 		</xsl:attribute>
+	</xsl:template>
+
+	<xsl:template name="HeatHarvestBaseFileName">
+		<xsl:param name="path"/>
+		<xsl:choose>
+			<xsl:when test="contains($path, '\')">
+				<xsl:call-template name="HeatHarvestBaseFileName">
+					<xsl:with-param name="path" select="substring-after($path, '\')"/>
+				</xsl:call-template>
+			</xsl:when>
+			<xsl:otherwise>
+				<xsl:value-of select="$path"/>
+			</xsl:otherwise>
+		</xsl:choose>
+	</xsl:template>
+
+	<!--
+		Remove single-File Heat components whose file basename is listed in heat-exclude.xml (same directory
+		as this XSL). Commit the empty list in heat-exclude.xml.template; generated heat-exclude.xml is gitignored.
+		Also drop ComponentRef rows that point at removed components (Heat -gg leaves refs in HarvestedAppFiles).
+	-->
+	<xsl:template match="*[local-name()='ComponentRef']" priority="2">
+		<xsl:variable name="rid" select="@Id"/>
+		<xsl:variable name="comp" select="//*[local-name()='Component'][@Id = $rid]"/>
+		<xsl:choose>
+			<xsl:when test="count($comp) = 0"/>
+			<xsl:when test="count($comp/*[local-name()='File']) = 1">
+				<xsl:variable name="src" select="string($comp/*[local-name()='File']/@Source)"/>
+				<xsl:variable name="base">
+					<xsl:call-template name="HeatHarvestBaseFileName">
+						<xsl:with-param name="path" select="translate($src, '/', '\')"/>
+					</xsl:call-template>
+				</xsl:variable>
+				<xsl:variable name="isExcluded">
+					<xsl:for-each select="document('heat-exclude.xml')">
+						<xsl:value-of select="count(/*[local-name()='HeatHarvestExcludes']/*[local-name()='Exclude'][@Name and translate(@Name, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz') = translate($base, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz')])"/>
+					</xsl:for-each>
+				</xsl:variable>
+				<xsl:choose>
+					<xsl:when test="$isExcluded &gt; 0"/>
+					<xsl:otherwise>
+						<xsl:copy>
+							<xsl:apply-templates select="@*|node()"/>
+						</xsl:copy>
+					</xsl:otherwise>
+				</xsl:choose>
+			</xsl:when>
+			<xsl:otherwise>
+				<xsl:copy>
+					<xsl:apply-templates select="@*|node()"/>
+				</xsl:copy>
+			</xsl:otherwise>
+		</xsl:choose>
+	</xsl:template>
+
+	<xsl:template match="*[local-name()='Component'][count(*[local-name()='File'])=1]" priority="1">
+		<xsl:variable name="src" select="string(*[local-name()='File']/@Source)"/>
+		<xsl:variable name="base">
+			<xsl:call-template name="HeatHarvestBaseFileName">
+				<xsl:with-param name="path" select="translate($src, '/', '\')"/>
+			</xsl:call-template>
+		</xsl:variable>
+		<xsl:variable name="isExcluded">
+			<xsl:for-each select="document('heat-exclude.xml')">
+				<xsl:value-of select="count(/*[local-name()='HeatHarvestExcludes']/*[local-name()='Exclude'][@Name and translate(@Name, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz') = translate($base, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz')])"/>
+			</xsl:for-each>
+		</xsl:variable>
+		<xsl:choose>
+			<xsl:when test="$isExcluded &gt; 0"/>
+			<xsl:otherwise>
+				<xsl:copy>
+					<xsl:apply-templates select="@*|node()"/>
+				</xsl:copy>
+			</xsl:otherwise>
+		</xsl:choose>
 	</xsl:template>
 </xsl:stylesheet>

--- a/BaseInstallerBuild/buildMsi.bat
+++ b/BaseInstallerBuild/buildMsi.bat
@@ -1,5 +1,6 @@
 @echo off
 call setVars.bat %*
+setlocal EnableDelayedExpansion
 
 (
 	@echo on
@@ -9,13 +10,15 @@ call setVars.bat %*
 
 ) && (
 	@REM Harvest (heat) the application and data files.
+	if not exist heat-exclude.xml copy /y heat-exclude.xml.template heat-exclude.xml
 	heat.exe dir %MASTERBUILDDIR% -cg HarvestedAppFiles -gg -scom -sreg -sfrag -srd -sw5150 -sw5151 -dr APPFOLDER -var var.MASTERBUILDDIR -t KeyPathFix.xsl -out AppHarvest.wxs
 	heat.exe dir %MASTERDATADIR% -cg HarvestedDataFiles -gg -scom -sreg -sfrag -srd -sw5150 -sw5151 -dr HARVESTDATAFOLDER -var var.MASTERDATADIR -t KeyPathFix.xsl -out DataHarvest.wxs
 ) && (
 	@REM Compile (candle) and Link (light) the MSI file.
 	candle.exe -arch %Arch% -dApplicationName=%AppName% -dSafeApplicationName=%SafeAppName% -dManufacturer=%Manufacturer% -dSafeManufacturer=%SafeManufacturer% -dVersionNumber=%Version% -dMajorVersion=%Major% -dMinorVersion=%Minor% -dMASTERBUILDDIR=%MASTERBUILDDIR% -dMASTERDATADIR=%MASTERDATADIR% -dUpgradeCode=%UPGRADECODEGUID% -dProductCode=%PRODUCTIDGUID% Framework.wxs AppHarvest.wxs DataHarvest.wxs WixUI_DialogFlow.wxs GIInstallDirDlg.wxs GIProgressDlg.wxs GIWelcomeDlg.wxs GICustomizeDlg.wxs GISetupTypeDlg.wxs -ext WixFirewallExtension -ext WixUtilExtension
 ) && (
-	light.exe Framework.wixobj AppHarvest.wixobj DataHarvest.wixobj WixUI_DialogFlow.wixobj GIInstallDirDlg.wixobj GIProgressDlg.wixobj GIWelcomeDlg.wixobj GICustomizeDlg.wixobj GISetupTypeDlg.wixobj -ext WixFirewallExtension -ext WixUIExtension -ext WixUtilExtension -cultures:en-us -loc WixUI_en-us.wxl %SuppressICE% -sw1076 -out %SafeAppName%_%Version%.msi
+	@REM Link (light): -fv adds fileVersion to MsiAssemblyName so GAC assemblies can service when AssemblyVersion is unchanged but file version increases (MSBuild: SetMsiAssemblyNameFileVersion=true).
+	light.exe Framework.wixobj AppHarvest.wixobj DataHarvest.wixobj WixUI_DialogFlow.wixobj GIInstallDirDlg.wixobj GIProgressDlg.wixobj GIWelcomeDlg.wixobj GICustomizeDlg.wixobj GISetupTypeDlg.wixobj -ext WixFirewallExtension -ext WixUIExtension -ext WixUtilExtension -cultures:en-us -loc WixUI_en-us.wxl %SuppressICE% -sw1076 -fv -out %SafeAppName%_%Version%.msi
 ) && (
 	call signingProxy %CD%\%SafeAppName%_%Version%.msi
 )

--- a/BaseInstallerBuild/heat-exclude.xml.template
+++ b/BaseInstallerBuild/heat-exclude.xml.template
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Template: copy to heat-exclude.xml (same folder as KeyPathFix.xsl) before running Heat, or let your
+  product build copy its own file to BaseInstallerBuild/heat-exclude.xml. buildMsi.bat seeds from this
+  template when heat-exclude.xml is missing.
+
+  Schema: each <Exclude Name="Some.dll" /> drops single-File Heat components (-gg) for that basename so
+  authored WiX can own the file. See KeyPathFix.xsl (document('heat-exclude.xml')).
+-->
+<HeatHarvestExcludes xmlns="http://fieldworks.sil.org/heat-harvest-excludes/1">
+</HeatHarvestExcludes>

--- a/README.md
+++ b/README.md
@@ -33,6 +33,20 @@ See https://github.com/sillsdev/genericinstaller-sample for a sample use.
 6)	In the `resources` folder there are several graphics files used by the installer. Customize these as you wish but do not change the names or dimensions of the images, nor check them in to the genericinstaller repository (see Working with Templates below).
 7)	Open a command prompt and run the Build*Base.bat file to build your installer. The installer will be created in the BuildDir folder in your repository if all goes well.
 
+### Heat harvest exclusions (`heat-exclude.xml`)
+
+Directory harvesting uses `BaseInstallerBuild/KeyPathFix.xsl`. That stylesheet loads **`heat-exclude.xml`** from the **same directory as the XSL** (via `document('heat-exclude.xml')`) and **drops** Heat-generated **single-`File`** components (`heat -gg`) when the harvested file’s **basename** matches an `<Exclude Name="Some.dll" />` entry. It also removes matching **`ComponentRef`** rows from **`HarvestedAppFiles`** so Light does not see dangling references (**LGHT0094**).
+
+**PatchableInstaller (generic template only)**
+
+- **`heat-exclude.xml.template`** is the only committed list file: an **empty** `<HeatHarvestExcludes>` with schema comments. **Do not** commit product-specific DLL names here.
+- **`heat-exclude.xml`** is **gitignored** (see `PatchableInstaller/.gitignore`). `buildMsi.bat` runs `copy /y heat-exclude.xml.template heat-exclude.xml` when `heat-exclude.xml` is missing so Heat always has a valid file.
+
+**Downstream products (e.g. FieldWorks in this monorepo)**
+
+- Ship a product-specific list and copy it over **`BaseInstallerBuild/heat-exclude.xml`** before **`buildBaseInstaller.bat`** / **`buildMsi.bat`**. WiX 6 products can keep a list next to that tree’s **`KeyPathFix.xsl`**.
+- If you exclude assemblies from Heat, author matching components (for example in **`CustomComponents.wxi`**) and add **`ComponentRef`** entries under **`Feature Complete`** in your overlaid **`Common/CustomFeatures.wxi`** (FieldWorks: **`FLExInstaller/CustomFeatures.wxi`** is copied with other **`*.wxi`** into **`PatchableInstaller/Common`**).
+
 ### Working with Templates:
 This installer template is designed to be customizable with your own logos, license, etc., but customizing templates in shared locations is inconsiderate. Instead, your options include:
  - creating your own fork or branch of this repository (depending on whether you belong to the sillsdev organization)
@@ -46,16 +60,11 @@ If you do not wish to use the build scripts from the sample project, simply:
 * (possible other steps)
 * Call `BaseInstallerBuild\buildBaseInstaller.bat` and `CreateUpdatePatch\buildPatch.bat` passing the arguments listed at the beginnig of the respective scripts (see the end of Sample.(build|targets) for sample usage)
 
-### Working with Templates:
-This installer template is designed to be customizable with your own logos, license, etc., but customizing templates in shared locations is inconsiderate. Instead, your options include:
- - creating your own fork or branch of this repository (depending on whether you belong to the sillsdev organization)
- - keeping the customized items in your product's main repository and copying them on top of the template items as a build step (remember not to check them in--TODO: after the generic installer is more stable, .gitignore popularly-replaced files)
-
 Popular Templates Include:
  - Icons under `resources`
  - `resources\License.htm`
  - `Common\Overrides.wxi` allows custom pre- and post-install actions as well as some custom paths
- - `Common\CustomFeatures.wxi` allows the inclusion of custom features for the user to be able to select
+ - `Common\CustomFeatures.wxi` allows the inclusion of custom features for the user to be able to select, including any extra `ComponentRef` entries needed for `Feature Complete` when assemblies are excluded from Heat (see README heat-exclude section).
 
 ### Work TODO:
  - Add a choose components window in MSI UI?


### PR DESCRIPTION
* In order to support installing some assemblies in the GAC to fix signed third party assembly loading issues we need to allow excluding assemblies and adding them into the custom component. We also need to use file version as some 3rd party assemblies done update AssemblyVersion on important updates

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/genericinstaller/84)
<!-- Reviewable:end -->
