### PR TITLE
LT-20524: Resolve install directories in silent (/quiet) installs

### DIFF
--- a/BaseInstallerBuild/Framework.wxs
+++ b/BaseInstallerBuild/Framework.wxs
@@ -123,6 +123,23 @@
 		<Custom Action='NoDowngrade' After='FindRelatedProducts'>NEWERFOUND</Custom>
 		<Custom Action="CheckPatchValue" Before="CheckUpgradeValue">PATCHNEWSUMMARYSUBJECT="Small Update Patch"</Custom>
 		<Custom Action="CheckUpgradeValue" After="InstallFinalize">PREVIOUSFOUND</Custom>
+		<!-- LT-20524: The InstallUISequence does not run for silent (/quiet, /qn) or basic (/qb) installs
+		     (UILevel &lt; 4), so the directory-resolution actions below must also run here; otherwise
+		     APPFOLDER/DATAFOLDER/HARVESTDATAFOLDER stay unset and files (including the ICU data that
+		     ICU_DATA points at) install to the wrong locations. Reduced (/passive, UILevel 4) and full
+		     UI installs continue to resolve these in the InstallUISequence, so the UILevel guard keeps
+		     this from overriding a user-chosen path. VerifyDataPath populates REGDATAFOLDER (used by the
+		     conditions below) and always returns Success, so it is safe in a silent install. -->
+		<Custom Action="SetDefDataFolder" After="FindRelatedProducts">UILevel &lt; 4</Custom>
+		<Custom Action="VerifyDataPath" After="SetDefDataFolder">UILevel &lt; 4</Custom>
+		<Custom Action="UseDefAppFolder" After="AppSearch">(UILevel &lt; 4) and (NOT REGAPPFOLDER) and (NOT OVRAPPFOLDER)</Custom>
+		<Custom Action="UseOvrAppFolder" After="AppSearch">(UILevel &lt; 4) and (NOT REGAPPFOLDER) and (OVRAPPFOLDER)</Custom>
+		<Custom Action="UseRegAppFolder" After="AppSearch">(UILevel &lt; 4) and (REGAPPFOLDER)</Custom>
+		<Custom Action="UseDefDataFolder" After="AppSearch">(UILevel &lt; 4) and (NOT REGDATAFOLDER) and (NOT OVRDATAFOLDER)</Custom>
+		<Custom Action="UseOvrDataFolder" After="AppSearch">(UILevel &lt; 4) and (NOT REGDATAFOLDER) and (OVRDATAFOLDER)</Custom>
+		<Custom Action="UseRegDataFolder" After="AppSearch">(UILevel &lt; 4) and (REGDATAFOLDER)</Custom>
+		<Custom Action="UseDefHarvestDataFolder" After="AppSearch">(UILevel &lt; 4) and (NOT OVRHARVESTDATAFOLDER)</Custom>
+		<Custom Action="UseOvrHarvestDataFolder" After="AppSearch">(UILevel &lt; 4) and (OVRHARVESTDATAFOLDER)</Custom>
 		<?include ../Common/CustomActionSteps.wxi?>
 	</InstallExecuteSequence>
 


### PR DESCRIPTION
## Problem

[LT-20524](https://jira.sil.org/browse/LT-20524) — applications built
on this installer (for example FieldWorks) fail to install in `/quiet`
mode (PDQ Deploy / PDQ Connect / Intune).

The directory-resolution custom actions (`SetDefDataFolder`,
`VerifyDataPath`, and the `Use*AppFolder` / `Use*DataFolder` /
`Use*HarvestDataFolder` set) were scheduled **only** in the
`InstallUISequence`. Windows Installer skips that sequence for silent
(`/quiet`, `/qn`) and basic-UI (`/qb`) installs, so `APPFOLDER`,
`DATAFOLDER`, and `HARVESTDATAFOLDER` were never assigned. The
application and its harvested data then installed to the wrong
locations. For FieldWorks, that also broke `ICU_DATA` resolution and
caused a crash on first use. `/passive` worked only because it still ran
the reduced-UI sequence.

## Fix

Schedule the same directory-resolution actions in the
`InstallExecuteSequence`, guarded by `UILevel < 4` so they run **only**
when the UI sequence is skipped. Reduced (`/passive`) and full UI
installs continue to resolve these in the `InstallUISequence`, so a
user-chosen path is never overridden. `VerifyDataPath` populates
`REGDATAFOLDER` (used by the conditions) and always returns `Success`,
so it is safe in a silent install.

This is the corresponding legacy WiX 3 change for the paired FieldWorks
WiX 6 PR: sillsdev/FieldWorks#937.

## Validation

- WiX authoring is schema-valid (no XML/WiX validation errors).
- Downstream validation was completed in the paired FieldWorks PR on the
  rebuilt WiX 6 MSI with elevated installs for `/quiet`, `/qb`,
  `/passive`, and full UI. In each successful mode, the app folder,
  data folder, harvested-data folder, and shortcuts resolved correctly.
- Direct legacy WiX 3 / genericinstaller smoke validation was **not**
  run in this workspace, so repo-local WiX 3 evidence is still pending.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/genericinstaller/86)
<!-- Reviewable:end -->