### PR TITLE
LT-20524: Resolve install directories in silent (/quiet) installs

### DIFF
--- a/BaseInstallerBuild/Framework.wxs
+++ b/BaseInstallerBuild/Framework.wxs
@@ -123,6 +123,23 @@
 		<Custom Action='NoDowngrade' After='FindRelatedProducts'>NEWERFOUND</Custom>
 		<Custom Action="CheckPatchValue" Before="CheckUpgradeValue">PATCHNEWSUMMARYSUBJECT="Small Update Patch"</Custom>
 		<Custom Action="CheckUpgradeValue" After="InstallFinalize">PREVIOUSFOUND</Custom>
+		<!-- LT-20524: The InstallUISequence does not run for silent (/quiet, /qn) or basic (/qb) installs
+		     (UILevel &lt; 4), so the directory-resolution actions below must also run here; otherwise
+		     APPFOLDER/DATAFOLDER/HARVESTDATAFOLDER stay unset and files (including the ICU data that
+		     ICU_DATA points at) install to the wrong locations. Reduced (/passive, UILevel 4) and full
+		     UI installs continue to resolve these in the InstallUISequence, so the UILevel guard keeps
+		     this from overriding a user-chosen path. VerifyDataPath populates REGDATAFOLDER (used by the
+		     conditions below) and always returns Success, so it is safe in a silent install. -->
+		<Custom Action="SetDefDataFolder" After="FindRelatedProducts">UILevel &lt; 4</Custom>
+		<Custom Action="VerifyDataPath" After="SetDefDataFolder">UILevel &lt; 4</Custom>
+		<Custom Action="UseDefAppFolder" After="AppSearch">(UILevel &lt; 4) and (NOT REGAPPFOLDER) and (NOT OVRAPPFOLDER)</Custom>
+		<Custom Action="UseOvrAppFolder" After="AppSearch">(UILevel &lt; 4) and (NOT REGAPPFOLDER) and (OVRAPPFOLDER)</Custom>
+		<Custom Action="UseRegAppFolder" After="AppSearch">(UILevel &lt; 4) and (REGAPPFOLDER)</Custom>
+		<Custom Action="UseDefDataFolder" After="AppSearch">(UILevel &lt; 4) and (NOT REGDATAFOLDER) and (NOT OVRDATAFOLDER)</Custom>
+		<Custom Action="UseOvrDataFolder" After="AppSearch">(UILevel &lt; 4) and (NOT REGDATAFOLDER) and (OVRDATAFOLDER)</Custom>
+		<Custom Action="UseRegDataFolder" After="AppSearch">(UILevel &lt; 4) and (REGDATAFOLDER)</Custom>
+		<Custom Action="UseDefHarvestDataFolder" After="AppSearch">(UILevel &lt; 4) and (NOT OVRHARVESTDATAFOLDER)</Custom>
+		<Custom Action="UseOvrHarvestDataFolder" After="AppSearch">(UILevel &lt; 4) and (OVRHARVESTDATAFOLDER)</Custom>
 		<?include ../Common/CustomActionSteps.wxi?>
 	</InstallExecuteSequence>
 


### PR DESCRIPTION
## LT-20524: Resolve install directories in silent (`/quiet`) installs

Replacement for #86, which was auto-closed when the source fork was deleted and can no longer be reopened. Same commit (`5e5c96a`).

### Problem
The directory-resolution custom actions (`SetDefDataFolder`, `VerifyDataPath`, and the `Use*AppFolder` / `Use*DataFolder` / `Use*HarvestDataFolder` set) were only scheduled in the **`InstallUISequence`**, which Windows Installer skips for silent (`/quiet`, `/qn`) and basic-UI (`/qb`) installs. `APPFOLDER`, `DATAFOLDER`, and `HARVESTDATAFOLDER` were therefore left unset, so:

- the registry `ProjectsDir` is written as the literal, unexpanded `c:\[DATAFOLDER]\`, and
- ICU data (Icu70) installs to `c:\` instead of `C:\ProgramData\SIL`.

### Fix
Schedule the same actions in the **`InstallExecuteSequence`**, guarded by `UILevel < 4` so they only run when the UI sequence does not. Reduced (`/passive`) and full-UI installs keep resolving these in the `InstallUISequence`, so user-chosen paths are not overridden. `VerifyDataPath` populates `REGDATAFOLDER` (used by the conditions) and always returns Success, so it is safe in a silent install.

### Impact
`master` (what the FieldWorks base-installer CD builds) does not contain this fix, so shipped installers still misplace the projects directory and ICU data under `/quiet`. This needs to land on `master` and a new base installer built for the fix to reach users.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/genericinstaller/87)
<!-- Reviewable:end -->
